### PR TITLE
Release v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrapay/jest-date-matchers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Centrapay Jest date matchers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Releases v1.1.1 with changes to [Import expect as a named module](https://github.com/centrapay/jest-date-matchers/pull/152).