### PR TITLE
update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrapay/jest-date-matchers",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Centrapay Jest date matchers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
missed this in https://github.com/centrapay/jest-date-matchers/pull/155, required to release to npm